### PR TITLE
Таск 120: Переход на экран деталей вакансии

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/details/ui/DetailsFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/details/ui/DetailsFragment.kt
@@ -1,24 +1,26 @@
 package ru.practicum.android.diploma.vacancy.details.ui
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
 
 class DetailsFragment : Fragment() {
 
     companion object {
-        fun newInstance() = DetailsFragment()
+        private const val ARGS_VACANCY_ID = "vacancy_id"
+        private const val NULL_ID = 0
+
+        fun createArgs(vacancyId: Int): Bundle =
+            bundleOf(ARGS_VACANCY_ID to vacancyId)
     }
 
-    private val viewModel: DetailsViewModel by viewModels()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
+    private val viewModel: DetailsViewModel by viewModel()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -26,5 +28,14 @@ class DetailsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         return inflater.inflate(R.layout.fragment_details, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val vacancyId = requireArguments().getInt(ARGS_VACANCY_ID) ?: NULL_ID
+
+        Log.d("VacancyID", "$vacancyId")
+        viewModel.loadVacancy(vacancyId)
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/details/ui/DetailsViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/details/ui/DetailsViewModel.kt
@@ -11,9 +11,9 @@ class DetailsViewModel(
     private val detailsInteractor: DetailsInteractor
 ) : ViewModel() {
 
-    fun loadVacancy() {
+    fun loadVacancy(vacancyId: Int) {
         viewModelScope.launch {
-            detailsInteractor.fetchDetails(TEST_ID)
+            detailsInteractor.fetchDetails(vacancyId)
                 .collect { resource ->
                     processResult(resource.first, resource.second)
                 }
@@ -33,10 +33,6 @@ class DetailsViewModel(
                 Log.d("VacancyResult", vacancy.toString())
             }
         }
-    }
-
-    companion object {
-        private const val TEST_ID = 114_036_543
     }
 }
 

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/search/ui/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/search/ui/SearchFragment.kt
@@ -7,20 +7,30 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import ru.practicum.android.diploma.R
+import ru.practicum.android.diploma.common.utils.debounce
 import ru.practicum.android.diploma.databinding.FragmentSearchBinding
+import ru.practicum.android.diploma.vacancy.details.ui.DetailsFragment
 import ru.practicum.android.diploma.vacancy.search.ui.adapter.VacancyAdapter
 
 class SearchFragment : Fragment() {
+
+    companion object {
+        private const val CLICK_DEBOUNCE_DELAY = 500L
+    }
 
     private var _binding: FragmentSearchBinding? = null
     private val binding get() = _binding!!
 
     private val viewModel: SearchViewModel by viewModel()
+    private lateinit var onVacancyClickDebounce: (Int) -> Unit
     private val vacancyAdapter by lazy {
         VacancyAdapter(emptyList()) { vacancy ->
-            // Обработка нажатия на вакансию при необходимости
+            onVacancyClickDebounce(vacancy.id)
         }
     }
 
@@ -49,6 +59,17 @@ class SearchFragment : Fragment() {
     private fun setupRecyclerView() {
         binding.recyclerView.layoutManager = LinearLayoutManager(context)
         binding.recyclerView.adapter = vacancyAdapter
+
+        onVacancyClickDebounce = debounce<Int>(
+            CLICK_DEBOUNCE_DELAY,
+            viewLifecycleOwner.lifecycleScope,
+            false
+        ) { vacancyId ->
+            findNavController().navigate(
+                R.id.action_searchFragment_to_detailsFragment,
+                DetailsFragment.createArgs(vacancyId)
+            )
+        }
     }
 
     private fun setupListeners() {

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -6,7 +6,8 @@
     android:layout_height="match_parent"
     android:layout_marginHorizontal="@dimen/dimens_16"
     android:background="@color/day_night"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:context=".vacancy.details.ui.DetailsFragment" >
 
     <LinearLayout
         android:id="@+id/ll_header"

--- a/app/src/main/res/navigation/root_navigation_graph.xml
+++ b/app/src/main/res/navigation/root_navigation_graph.xml
@@ -20,9 +20,6 @@
         android:name="ru.practicum.android.diploma.vacancy.details.ui.DetailsFragment"
         android:label="fragment_details"
         tools:layout="@layout/fragment_details">
-    <argument
-        android:name="vacancyId"
-        app:argType="string" />
     </fragment>
     <fragment
         android:id="@+id/searchFragment"


### PR DESCRIPTION
DetailsFragment.kt:
Переход с androidx.fragment.app.viewModels на org.koin.androidx.viewmodel.ext.android.viewModel В компаньонах создан аргумент для передачи ID вакансии в бандл фрагмента Удален неиспользуемый метод onCreate
Добавлено переопределение метода onViewCreated, в нем реализовано получение ID из бандла и тестовый запрос вакансии во viewModel

DetailsViewModel.kt:
Тестовый айди заменен на айди полученный из экрана поиска

fragment_details.xml:
верстка связана с фрагментом

root_navigation_graph.xml:
удален аргумент (надо будет потом научиться этим пользоваться), а пока передача через bundle

SearchFragment.kt:
Добавлена обработка нажатия на элемент списка
В настройку RecyclerView добавлена настройка задержки на элемент