### PR TITLE
❌ Если в приложении есть сохранённые непустые настройки параметров фильтрации, то кнопка фильтра на главном экране находится в подсвеченном состоянии. #197

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/search/ui/SearchFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/search/ui/SearchFragment.kt
@@ -55,6 +55,8 @@ class SearchFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        renderFilter()
+
         applyFilterSettingsAndSearch()
 
         onVacancyClickDebounce = debounce(
@@ -244,6 +246,21 @@ class SearchFragment : Fragment() {
         viewModel.getFilterSettings {
             val query = binding.editSearch.text.toString()
             viewModel.onSearchQueryChanged(query, forceUpdate = true)
+        }
+    }
+    private fun renderFilter() {
+        viewModel.getFilterSettings { filters ->
+            val isActive = filters?.let {
+                it.expectedSalary >= 0 ||
+                    it.notShowWithoutSalary ||
+                    it.region != null ||
+                    it.industry != null ||
+                    it.country != null
+            } ?: false
+
+            binding.buttonFilter.setImageResource(
+                if (isActive) R.drawable.filter_active else R.drawable.ic_filter
+            )
         }
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/vacancy/search/ui/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/vacancy/search/ui/SearchViewModel.kt
@@ -204,11 +204,12 @@ class SearchViewModel(
     private var _isLoading = false
     val isLoading: Boolean get() = _isLoading
 
-    fun getFilterSettings(callback: (() -> Unit)? = null) {
+    fun getFilterSettings(callback: (FilterSettings?) -> Unit) {
         viewModelScope.launch {
             val settings = filterSettingsInteractor.getFilterSettings()
             currentFilterSettings = settings
-            callback?.invoke()
+            callback(settings)
         }
     }
+
 }


### PR DESCRIPTION
[Screen_recording_20250103_172551.webm](https://github.com/user-attachments/assets/d9e127c5-481a-4b01-8e29-db1dce3ff7bf)
